### PR TITLE
Problem: integer decoding not efficient

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -23,9 +23,15 @@ var (
 	// ErrInvalidOffsetForArrayElement is returned when the offset for an array element is invalid
 	ErrInvalidOffsetForArrayElement = errors.New("invalid offset for array element")
 
-	// ErrNegativeSize is returned when an offset or length is negative
-	ErrNegativeSize = errors.New("negative size")
+	// ErrSizeOverflow is returned when an offset or length is negative
+	ErrSizeOverflow = errors.New("size overflow")
 
 	// ErrDirtyPadding is returned when padding bytes are not expected
 	ErrDirtyPadding = errors.New("dirty padding")
+
+	// ErrNegativeValue is returned when a negative value is provided for an unsigned type
+	ErrNegativeValue = errors.New("negative value for unsigned type")
+
+	// ErrIntegerTooLarge is returned when an integer value exceeds 256 bits
+	ErrIntegerTooLarge = errors.New("integer too large")
 )

--- a/generator/utils.go
+++ b/generator/utils.go
@@ -159,3 +159,17 @@ func ParseImport(imp string) ImportSpec {
 	}
 	return spec
 }
+
+// nativeSize returns the closest native size for a given int size s
+func nativeSize(s int) int {
+	switch {
+	case s <= 8:
+		return 8
+	case s <= 16:
+		return 16
+	case s <= 32:
+		return 32
+	default:
+		return 64
+	}
+}

--- a/human_test.go
+++ b/human_test.go
@@ -226,14 +226,13 @@ func TestParseHumanReadableABI(t *testing.T) {
 		},
 		{
 			name:  "function with non-standard small integers",
-			input: []string{"function nonStandardIntegers(uint24 u24, uint36 u36, uint48 u48, uint72 u72, uint96 u96, uint120 u120, int24 i24, int36 i36, int48 i48, int72 i72, int96 i96, int120 i120)"},
+			input: []string{"function nonStandardIntegers(uint24 u24, uint48 u48, uint72 u72, uint96 u96, uint120 u120, int24 i24, int36 i36, int48 i48, int72 i72, int96 i96, int120 i120)"},
 			expected: `[
 				{
 					"type": "function",
 					"name": "nonStandardIntegers",
 					"inputs": [
 						{"name": "u24", "type": "uint24"},
-						{"name": "u36", "type": "uint36"},
 						{"name": "u48", "type": "uint48"},
 						{"name": "u72", "type": "uint72"},
 						{"name": "u96", "type": "uint96"},

--- a/stdlib.abi.go
+++ b/stdlib.abi.go
@@ -917,12 +917,10 @@ func EncodeBytesSlice(value [][]byte, buf []byte) (int, error) {
 
 // EncodeInt16 encodes int16 to ABI bytes
 func EncodeInt16(value int16, buf []byte) (int, error) {
-	if value < 0 {
-		for i := 0; i < 30; i++ {
-			buf[i] = 0xff
-		}
-	}
 	binary.BigEndian.PutUint16(buf[30:32], uint16(value))
+	if value < 0 {
+		copy(buf, PaddingBytes16)
+	}
 	return 32, nil
 }
 
@@ -947,12 +945,10 @@ func EncodeInt16Slice(value []int16, buf []byte) (int, error) {
 
 // EncodeInt24 encodes int24 to ABI bytes
 func EncodeInt24(value int32, buf []byte) (int, error) {
-	if value < 0 {
-		for i := 0; i < 28; i++ {
-			buf[i] = 0xff
-		}
-	}
 	binary.BigEndian.PutUint32(buf[28:32], uint32(value))
+	if value < 0 {
+		copy(buf, PaddingBytes32)
+	}
 	return 32, nil
 }
 
@@ -1004,12 +1000,10 @@ func EncodeInt256Slice(value []*big.Int, buf []byte) (int, error) {
 
 // EncodeInt32 encodes int32 to ABI bytes
 func EncodeInt32(value int32, buf []byte) (int, error) {
-	if value < 0 {
-		for i := 0; i < 28; i++ {
-			buf[i] = 0xff
-		}
-	}
 	binary.BigEndian.PutUint32(buf[28:32], uint32(value))
+	if value < 0 {
+		copy(buf, PaddingBytes32)
+	}
 	return 32, nil
 }
 
@@ -1034,12 +1028,10 @@ func EncodeInt32Slice(value []int32, buf []byte) (int, error) {
 
 // EncodeInt40 encodes int40 to ABI bytes
 func EncodeInt40(value int64, buf []byte) (int, error) {
-	if value < 0 {
-		for i := 0; i < 24; i++ {
-			buf[i] = 0xff
-		}
-	}
 	binary.BigEndian.PutUint64(buf[24:32], uint64(value))
+	if value < 0 {
+		copy(buf, PaddingBytes64)
+	}
 	return 32, nil
 }
 
@@ -1064,12 +1056,10 @@ func EncodeInt40Slice(value []int64, buf []byte) (int, error) {
 
 // EncodeInt48 encodes int48 to ABI bytes
 func EncodeInt48(value int64, buf []byte) (int, error) {
-	if value < 0 {
-		for i := 0; i < 24; i++ {
-			buf[i] = 0xff
-		}
-	}
 	binary.BigEndian.PutUint64(buf[24:32], uint64(value))
+	if value < 0 {
+		copy(buf, PaddingBytes64)
+	}
 	return 32, nil
 }
 
@@ -1094,12 +1084,10 @@ func EncodeInt48Slice(value []int64, buf []byte) (int, error) {
 
 // EncodeInt56 encodes int56 to ABI bytes
 func EncodeInt56(value int64, buf []byte) (int, error) {
-	if value < 0 {
-		for i := 0; i < 24; i++ {
-			buf[i] = 0xff
-		}
-	}
 	binary.BigEndian.PutUint64(buf[24:32], uint64(value))
+	if value < 0 {
+		copy(buf, PaddingBytes64)
+	}
 	return 32, nil
 }
 
@@ -1124,12 +1112,10 @@ func EncodeInt56Slice(value []int64, buf []byte) (int, error) {
 
 // EncodeInt64 encodes int64 to ABI bytes
 func EncodeInt64(value int64, buf []byte) (int, error) {
-	if value < 0 {
-		for i := 0; i < 24; i++ {
-			buf[i] = 0xff
-		}
-	}
 	binary.BigEndian.PutUint64(buf[24:32], uint64(value))
+	if value < 0 {
+		copy(buf, PaddingBytes64)
+	}
 	return 32, nil
 }
 
@@ -1154,12 +1140,10 @@ func EncodeInt64Slice(value []int64, buf []byte) (int, error) {
 
 // EncodeInt8 encodes int8 to ABI bytes
 func EncodeInt8(value int8, buf []byte) (int, error) {
-	if value < 0 {
-		for i := 0; i < 31; i++ {
-			buf[i] = 0xff
-		}
-	}
 	buf[31] = byte(value)
+	if value < 0 {
+		copy(buf, PaddingBytes8)
+	}
 	return 32, nil
 }
 
@@ -3321,23 +3305,10 @@ func DecodeBytesSlice(data []byte) ([][]byte, int, error) {
 
 // DecodeInt16 decodes int16 from ABI bytes
 func DecodeInt16(data []byte) (int16, int, error) {
-	// Validate sign extension for int16 (padding bytes: 30)
-	if data[30]&0x80 != 0 {
-		// Negative value, check all padding bytes are 0xFF
-		for i := 0; i < 30; i++ {
-			if data[i] != 0xFF {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
-	} else {
-		// Non-negative value, check all padding bytes are zero
-		for i := 0; i < 30; i++ {
-			if data[i] != 0x00 {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
+	result, err := DecodeInt[int16](data, MinInt16, MaxInt16)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := int16(binary.BigEndian.Uint16(data[30:32]))
 	return result, 32, nil
 }
 
@@ -3373,24 +3344,10 @@ func DecodeInt16Slice(data []byte) ([]int16, int, error) {
 
 // DecodeInt24 decodes int24 from ABI bytes
 func DecodeInt24(data []byte) (int32, int, error) {
-	// Validate sign extension for int24 (padding bytes: 29)
-	if data[29]&0x80 != 0 {
-		// Negative value, check all padding bytes are 0xFF
-		for i := 0; i < 29; i++ {
-			if data[i] != 0xFF {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
-	} else {
-		// Non-negative value, check all padding bytes are zero
-		for i := 0; i < 29; i++ {
-			if data[i] != 0x00 {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
+	result, err := DecodeInt[int32](data, MinInt24, MaxInt24)
+	if err != nil {
+		return 0, 0, err
 	}
-	// Decode int24 using int32
-	result := int32(binary.BigEndian.Uint32(data[28:32]))
 	return result, 32, nil
 }
 
@@ -3465,24 +3422,10 @@ func DecodeInt256Slice(data []byte) ([]*big.Int, int, error) {
 
 // DecodeInt32 decodes int32 from ABI bytes
 func DecodeInt32(data []byte) (int32, int, error) {
-	// Validate sign extension for int32 (padding bytes: 28)
-	if data[28]&0x80 != 0 {
-		// Negative value, check all padding bytes are 0xFF
-		for i := 0; i < 28; i++ {
-			if data[i] != 0xFF {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
-	} else {
-		// Non-negative value, check all padding bytes are zero
-		for i := 0; i < 28; i++ {
-			if data[i] != 0x00 {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
+	result, err := DecodeInt[int32](data, MinInt32, MaxInt32)
+	if err != nil {
+		return 0, 0, err
 	}
-	// Decode int32 using int32
-	result := int32(binary.BigEndian.Uint32(data[28:32]))
 	return result, 32, nil
 }
 
@@ -3518,24 +3461,10 @@ func DecodeInt32Slice(data []byte) ([]int32, int, error) {
 
 // DecodeInt40 decodes int40 from ABI bytes
 func DecodeInt40(data []byte) (int64, int, error) {
-	// Validate sign extension for int40 (padding bytes: 27)
-	if data[27]&0x80 != 0 {
-		// Negative value, check all padding bytes are 0xFF
-		for i := 0; i < 27; i++ {
-			if data[i] != 0xFF {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
-	} else {
-		// Non-negative value, check all padding bytes are zero
-		for i := 0; i < 27; i++ {
-			if data[i] != 0x00 {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
+	result, err := DecodeInt[int64](data, MinInt40, MaxInt40)
+	if err != nil {
+		return 0, 0, err
 	}
-	// Decode int40 using int64
-	result := int64(binary.BigEndian.Uint64(data[24:32]))
 	return result, 32, nil
 }
 
@@ -3571,24 +3500,10 @@ func DecodeInt40Slice(data []byte) ([]int64, int, error) {
 
 // DecodeInt48 decodes int48 from ABI bytes
 func DecodeInt48(data []byte) (int64, int, error) {
-	// Validate sign extension for int48 (padding bytes: 26)
-	if data[26]&0x80 != 0 {
-		// Negative value, check all padding bytes are 0xFF
-		for i := 0; i < 26; i++ {
-			if data[i] != 0xFF {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
-	} else {
-		// Non-negative value, check all padding bytes are zero
-		for i := 0; i < 26; i++ {
-			if data[i] != 0x00 {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
+	result, err := DecodeInt[int64](data, MinInt48, MaxInt48)
+	if err != nil {
+		return 0, 0, err
 	}
-	// Decode int48 using int64
-	result := int64(binary.BigEndian.Uint64(data[24:32]))
 	return result, 32, nil
 }
 
@@ -3624,24 +3539,10 @@ func DecodeInt48Slice(data []byte) ([]int64, int, error) {
 
 // DecodeInt56 decodes int56 from ABI bytes
 func DecodeInt56(data []byte) (int64, int, error) {
-	// Validate sign extension for int56 (padding bytes: 25)
-	if data[25]&0x80 != 0 {
-		// Negative value, check all padding bytes are 0xFF
-		for i := 0; i < 25; i++ {
-			if data[i] != 0xFF {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
-	} else {
-		// Non-negative value, check all padding bytes are zero
-		for i := 0; i < 25; i++ {
-			if data[i] != 0x00 {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
+	result, err := DecodeInt[int64](data, MinInt56, MaxInt56)
+	if err != nil {
+		return 0, 0, err
 	}
-	// Decode int56 using int64
-	result := int64(binary.BigEndian.Uint64(data[24:32]))
 	return result, 32, nil
 }
 
@@ -3677,24 +3578,10 @@ func DecodeInt56Slice(data []byte) ([]int64, int, error) {
 
 // DecodeInt64 decodes int64 from ABI bytes
 func DecodeInt64(data []byte) (int64, int, error) {
-	// Validate sign extension for int64 (padding bytes: 24)
-	if data[24]&0x80 != 0 {
-		// Negative value, check all padding bytes are 0xFF
-		for i := 0; i < 24; i++ {
-			if data[i] != 0xFF {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
-	} else {
-		// Non-negative value, check all padding bytes are zero
-		for i := 0; i < 24; i++ {
-			if data[i] != 0x00 {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
+	result, err := DecodeInt[int64](data, MinInt64, MaxInt64)
+	if err != nil {
+		return 0, 0, err
 	}
-	// Decode int64 using int64
-	result := int64(binary.BigEndian.Uint64(data[24:32]))
 	return result, 32, nil
 }
 
@@ -3730,23 +3617,10 @@ func DecodeInt64Slice(data []byte) ([]int64, int, error) {
 
 // DecodeInt8 decodes int8 from ABI bytes
 func DecodeInt8(data []byte) (int8, int, error) {
-	// Validate sign extension for int8 (padding bytes: 31)
-	if data[31]&0x80 != 0 {
-		// Negative value, check all padding bytes are 0xFF
-		for i := 0; i < 31; i++ {
-			if data[i] != 0xFF {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
-	} else {
-		// Non-negative value, check all padding bytes are zero
-		for i := 0; i < 31; i++ {
-			if data[i] != 0x00 {
-				return 0, 0, ErrDirtyPadding
-			}
-		}
+	result, err := DecodeInt[int8](data, MinInt8, MaxInt8)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := int8(data[31])
 	return result, 32, nil
 }
 
@@ -3848,13 +3722,10 @@ func DecodeStringSlice(data []byte) ([]string, int, error) {
 
 // DecodeUint16 decodes uint16 from ABI bytes
 func DecodeUint16(data []byte) (uint16, int, error) {
-	// Validate no extra bits are set for uint16 (padding bytes: 30)
-	for i := 0; i < 30; i++ {
-		if data[i] != 0x00 {
-			return 0, 0, ErrDirtyPadding
-		}
+	result, err := DecodeUint[uint16](data, MaxUint16)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := binary.BigEndian.Uint16(data[30:32])
 	return result, 32, nil
 }
 
@@ -3890,13 +3761,10 @@ func DecodeUint16Slice(data []byte) ([]uint16, int, error) {
 
 // DecodeUint24 decodes uint24 from ABI bytes
 func DecodeUint24(data []byte) (uint32, int, error) {
-	// Validate no extra bits are set for uint24 (padding bytes: 29)
-	for i := 0; i < 29; i++ {
-		if data[i] != 0x00 {
-			return 0, 0, ErrDirtyPadding
-		}
+	result, err := DecodeUint[uint32](data, MaxUint24)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := binary.BigEndian.Uint32(data[28:32])
 	return result, 32, nil
 }
 
@@ -3971,13 +3839,10 @@ func DecodeUint256Slice(data []byte) ([]*big.Int, int, error) {
 
 // DecodeUint32 decodes uint32 from ABI bytes
 func DecodeUint32(data []byte) (uint32, int, error) {
-	// Validate no extra bits are set for uint32 (padding bytes: 28)
-	for i := 0; i < 28; i++ {
-		if data[i] != 0x00 {
-			return 0, 0, ErrDirtyPadding
-		}
+	result, err := DecodeUint[uint32](data, MaxUint32)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := binary.BigEndian.Uint32(data[28:32])
 	return result, 32, nil
 }
 
@@ -4013,13 +3878,10 @@ func DecodeUint32Slice(data []byte) ([]uint32, int, error) {
 
 // DecodeUint40 decodes uint40 from ABI bytes
 func DecodeUint40(data []byte) (uint64, int, error) {
-	// Validate no extra bits are set for uint40 (padding bytes: 27)
-	for i := 0; i < 27; i++ {
-		if data[i] != 0x00 {
-			return 0, 0, ErrDirtyPadding
-		}
+	result, err := DecodeUint[uint64](data, MaxUint40)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := binary.BigEndian.Uint64(data[24:32])
 	return result, 32, nil
 }
 
@@ -4055,13 +3917,10 @@ func DecodeUint40Slice(data []byte) ([]uint64, int, error) {
 
 // DecodeUint48 decodes uint48 from ABI bytes
 func DecodeUint48(data []byte) (uint64, int, error) {
-	// Validate no extra bits are set for uint48 (padding bytes: 26)
-	for i := 0; i < 26; i++ {
-		if data[i] != 0x00 {
-			return 0, 0, ErrDirtyPadding
-		}
+	result, err := DecodeUint[uint64](data, MaxUint48)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := binary.BigEndian.Uint64(data[24:32])
 	return result, 32, nil
 }
 
@@ -4097,13 +3956,10 @@ func DecodeUint48Slice(data []byte) ([]uint64, int, error) {
 
 // DecodeUint56 decodes uint56 from ABI bytes
 func DecodeUint56(data []byte) (uint64, int, error) {
-	// Validate no extra bits are set for uint56 (padding bytes: 25)
-	for i := 0; i < 25; i++ {
-		if data[i] != 0x00 {
-			return 0, 0, ErrDirtyPadding
-		}
+	result, err := DecodeUint[uint64](data, MaxUint56)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := binary.BigEndian.Uint64(data[24:32])
 	return result, 32, nil
 }
 
@@ -4139,13 +3995,10 @@ func DecodeUint56Slice(data []byte) ([]uint64, int, error) {
 
 // DecodeUint64 decodes uint64 from ABI bytes
 func DecodeUint64(data []byte) (uint64, int, error) {
-	// Validate no extra bits are set for uint64 (padding bytes: 24)
-	for i := 0; i < 24; i++ {
-		if data[i] != 0x00 {
-			return 0, 0, ErrDirtyPadding
-		}
+	result, err := DecodeUint[uint64](data, MaxUint64)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := binary.BigEndian.Uint64(data[24:32])
 	return result, 32, nil
 }
 
@@ -4181,13 +4034,10 @@ func DecodeUint64Slice(data []byte) ([]uint64, int, error) {
 
 // DecodeUint8 decodes uint8 from ABI bytes
 func DecodeUint8(data []byte) (uint8, int, error) {
-	// Validate no extra bits are set for uint8 (padding bytes: 31)
-	for i := 0; i < 31; i++ {
-		if data[i] != 0x00 {
-			return 0, 0, ErrDirtyPadding
-		}
+	result, err := DecodeUint[uint8](data, MaxUint8)
+	if err != nil {
+		return 0, 0, err
 	}
-	result := uint8(data[31])
 	return result, 32, nil
 }
 

--- a/tests/comprehensive_test.go
+++ b/tests/comprehensive_test.go
@@ -18,7 +18,7 @@ import (
 // ComprehensiveTestABI contains human-readable ABI definitions for comprehensive testing
 var ComprehensiveTestABI = []string{
 	"function testSmallIntegers(uint8 u8, uint16 u16, uint24 u24, uint32 u32, uint64 u64, int8 i8, int16 i16, int24 i24, int32 i32, int64 i64) returns (bool)",
-	"function testNonStandardIntegers(uint24 u24, uint36 u36, uint48 u48, uint72 u72, uint96 u96, uint120 u120, int24 i24, int36 i36, int48 i48, int72 i72, int96 i96, int120 i120) returns (bool)",
+	"function testNonStandardIntegers(uint24 u24, uint48 u48, uint72 u72, uint96 u96, uint120 u120, int24 i24, int48 i48, int72 i72, int96 i96, int120 i120) returns (bool)",
 	"function testFixedArrays(address[5] addresses, uint256[3] uints, bytes32[2] bytes32s) returns (bool)",
 	"function testFixedBytes(bytes3 data3, bytes7 data7, bytes15 data15) returns (bytes32)",
 	"function testNestedDynamicArrays(uint256[][] matrix, address[][3][] addressMatrix, string[][] dymMatrix) returns (bool)",
@@ -93,13 +93,11 @@ func TestComprehensiveSmallIntegers(t *testing.T) {
 func TestComprehensiveNonStandardIntegers(t *testing.T) {
 	args := &TestNonStandardIntegersCall{
 		U24:  1000,              // uint32 - fits in 32 bits
-		U36:  2000,              // uint64 - fits in 64 bits
 		U48:  3000,              // uint64 - fits in 64 bits
 		U72:  big.NewInt(4000),  // uint72 - exceeds 64 bits, uses big.Int
 		U96:  big.NewInt(5000),  // uint96 - exceeds 64 bits, uses big.Int
 		U120: big.NewInt(6000),  // uint120 - exceeds 64 bits, uses big.Int
 		I24:  -1000,             // int32 - fits in 32 bits
-		I36:  -2000,             // int64 - fits in 64 bits
 		I48:  -3000,             // int64 - fits in 64 bits
 		I72:  big.NewInt(-4000), // int72 - exceeds 64 bits, uses big.Int
 		I96:  big.NewInt(-5000), // int96 - exceeds 64 bits, uses big.Int
@@ -113,12 +111,12 @@ func TestComprehensiveNonStandardIntegers(t *testing.T) {
 	// Test encoding
 	encoded, err := args.EncodeWithSelector()
 	require.NoError(t, err)
-	require.Equal(t, 4+384, len(encoded)) // 4 bytes selector + 384 bytes data
+	require.Equal(t, 4+320, len(encoded)) // 4 bytes selector + 384 bytes data
 
 	// Get go-ethereum encoding
 	goEthEncoded, err := ComprehensiveTestABIDef.Pack("testNonStandardIntegers",
-		big.NewInt(int64(args.U24)), big.NewInt(int64(args.U36)), big.NewInt(int64(args.U48)), args.U72, args.U96, args.U120,
-		big.NewInt(int64(args.I24)), big.NewInt(int64(args.I36)), big.NewInt(int64(args.I48)), args.I72, args.I96, args.I120)
+		big.NewInt(int64(args.U24)), big.NewInt(int64(args.U48)), args.U72, args.U96, args.U120,
+		big.NewInt(int64(args.I24)), big.NewInt(int64(args.I48)), args.I72, args.I96, args.I120)
 	require.NoError(t, err)
 
 	require.Equal(t, encoded, goEthEncoded)

--- a/utils_test.go
+++ b/utils_test.go
@@ -134,6 +134,12 @@ func TestDecodeBigInt(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expected, result)
+
+				// roundtrip
+				buf := make([]byte, 32)
+				err = EncodeBigInt(result, buf, tt.signed)
+				require.NoError(t, err)
+				require.Equal(t, tt.data, hex.EncodeToString(buf))
 			}
 		})
 	}


### PR DESCRIPTION
Solution:
- optimize small integers decoding using uint256
- cleanup negative big.Int handling

```
$ go test -bench=GoABI -benchmem -count=6 ./tests/... -run ^$ > /tmp/bench.after
$ benchstat /tmp/bench.before /tmp/bench.after
oos: darwin
goarch: arm64
pkg: github.com/yihuang/go-abi/tests
cpu: Apple M3 Max
                                         │ /tmp/bench.before │          /tmp/bench.after          │
                                         │      sec/op       │   sec/op     vs base               │
GoABI_Decode_ComplexDynamicTuples-16            1381.0n ± 1%   903.3n ± 2%  -34.59% (p=0.002 n=6)
GoABI_Decode_NestedDynamicArrays-16              803.8n ± 1%   665.1n ± 2%  -17.26% (p=0.002 n=6)
GoABI_Decode_MixedTypes-16                       269.7n ± 2%   139.0n ± 1%  -48.45% (p=0.002 n=6)
GoABI_ComplexDynamicTuples-16                    436.0n ± 1%   439.2n ± 1%        ~ (p=0.093 n=6)
GoABI_NestedDynamicArrays-16                     287.2n ± 3%   286.7n ± 3%        ~ (p=0.937 n=6)
GoABI_MixedTypes-16                              132.2n ± 1%   134.3n ± 2%   +1.55% (p=0.004 n=6)
GoABI_EncodeOnly_ComplexDynamicTuples-16         435.9n ± 1%   433.2n ± 2%        ~ (p=0.485 n=6)
GoABI_EncodeTo_ComplexDynamicTuples-16           146.6n ± 1%   146.4n ± 1%        ~ (p=0.619 n=6)
GoABI_Encode_SmallIntegers-16                    86.04n ± 1%   52.88n ± 2%  -38.55% (p=0.002 n=6)
geomean                                          311.0n        256.1n       -17.68%

                                         │ /tmp/bench.before │           /tmp/bench.after           │
                                         │       B/op        │     B/op      vs base                │
GoABI_Decode_ComplexDynamicTuples-16          1.289Ki ± 0%     1.289Ki ± 0%       ~ (p=1.000 n=6) ¹
GoABI_Decode_NestedDynamicArrays-16           1.453Ki ± 0%     1.453Ki ± 0%       ~ (p=1.000 n=6) ¹
GoABI_Decode_MixedTypes-16                      128.0 ± 0%       128.0 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_ComplexDynamicTuples-16                 3.000Ki ± 0%     3.000Ki ± 0%       ~ (p=1.000 n=6) ¹
GoABI_NestedDynamicArrays-16                  1.250Ki ± 0%     1.250Ki ± 0%       ~ (p=1.000 n=6) ¹
GoABI_MixedTypes-16                             896.0 ± 0%       896.0 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_EncodeOnly_ComplexDynamicTuples-16      3.000Ki ± 0%     3.000Ki ± 0%       ~ (p=1.000 n=6) ¹
GoABI_EncodeTo_ComplexDynamicTuples-16          0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_Encode_SmallIntegers-16                   352.0 ± 0%       352.0 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                    ²                 +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                         │ /tmp/bench.before │          /tmp/bench.after          │
                                         │     allocs/op     │ allocs/op   vs base                │
GoABI_Decode_ComplexDynamicTuples-16            39.00 ± 0%     39.00 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_Decode_NestedDynamicArrays-16             31.00 ± 0%     31.00 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_Decode_MixedTypes-16                      1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_ComplexDynamicTuples-16                   1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_NestedDynamicArrays-16                    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_MixedTypes-16                             1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_EncodeOnly_ComplexDynamicTuples-16        1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_EncodeTo_ComplexDynamicTuples-16          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
GoABI_Encode_SmallIntegers-16                   1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                                                    ²               +0.00%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```